### PR TITLE
Some walls not showing on the output has been fixed

### DIFF
--- a/FloorplanToBlenderLib/generator.py
+++ b/FloorplanToBlenderLib/generator.py
@@ -126,8 +126,18 @@ class Wall(Generator):
         # detect contour
         contour, _ = detect.outer_contours(gray)
 
+        # get bounding Rect of the outer_contours
+        (x, y, w, h) = cv2.boundingRect(contour)
+        p1 = [x, y]
+        p2 = [x, y + h]
+        p3 = [x + w, y + h]
+        p4 = [x + w, y]
+        pts = np.array([p1, p2, p3, p4], np.int32)
+        pts = pts.reshape(-1, 1, 2)
+
         # remove walls outside of contour
-        boxes = calculate.remove_walls_not_in_contour(boxes, contour)
+        boxes = calculate.remove_walls_not_in_contour(boxes, pts)
+        # boxes = calculate.remove_walls_not_in_contour(boxes, contour)
         # Convert boxes to verts and faces, vertically
         self.verts, self.faces, wall_amount = transform.create_nx4_verts_and_faces(
             boxes=boxes,


### PR DESCRIPTION
The code shown in the remove_walls_not_int_contour is using cv2.pointPolygonTest() to see if the wall is inside the outer contour or not.
However, some floorplan's outer contour was too tight for the wall bounding rectangle box that it detected some walls as if it was outside of the outer contour.

So one way I tried fixing this issue was instead of doing a pointPolygonTest with a outer contour of the house , which is an output from

```
# detect contour
contour, _ = detect.outer_contours(gray)
```

I tried it with a bounding rectangle box of a outer contour of a house.

the code below is what I did.

```
# detect contour
contour, _ = detect.outer_contours(gray)

(x, y, w, h) = cv2.boundingRect(contour)
p1 = [x, y]
p2 = [x, y + h]
p3 = [x + w, y + h]
p4 = [x + w, y]
pts = np.array([p1, p2, p3, p4], np.int32)
pts = pts.reshape(-1, 1, 2)

# remove walls outside of contour
boxes = calculate.remove_walls_not_in_contour(boxes, pts)

```