### PR TITLE
Fix for walls missing in final 3D blender product

### DIFF
--- a/FloorplanToBlenderLib/calculate.py
+++ b/FloorplanToBlenderLib/calculate.py
@@ -33,13 +33,10 @@ def remove_walls_not_in_contour(walls, contour):
     """
     res = []
     for wall in walls:
-        (x, y, w, h) = cv2.boundingRect(wall)
-        p1 = (x, y)
-        p2 = (x, y + h)
-        p3 = (x + w, y + h)
-        p4 = (x + w, y)
-        if points_inside_contour([p1, p2, p3, p4], contour):
-            res.append(wall)
+        for point in wall:
+            if points_inside_contour(point, contour):
+                res.append(wall)
+                break
     return res
 
 

--- a/FloorplanToBlenderLib/generator.py
+++ b/FloorplanToBlenderLib/generator.py
@@ -126,8 +126,18 @@ class Wall(Generator):
         # detect contour
         contour, _ = detect.outer_contours(gray)
 
+        # get bounding Rect of the outer_contours
+        (x, y, w, h) = cv2.boundingRect(contour)
+        p1 = [x, y]
+        p2 = [x, y + h]
+        p3 = [x + w, y + h]
+        p4 = [x + w, y]
+        pts = np.array([p1, p2, p3, p4], np.int32)
+        pts = pts.reshape(-1, 1, 2)
+
         # remove walls outside of contour
-        boxes = calculate.remove_walls_not_in_contour(boxes, contour)
+        boxes = calculate.remove_walls_not_in_contour(boxes, pts)
+        # boxes = calculate.remove_walls_not_in_contour(boxes, contour)
         # Convert boxes to verts and faces, vertically
         self.verts, self.faces, wall_amount = transform.create_nx4_verts_and_faces(
             boxes=boxes,

--- a/FloorplanToBlenderLib/generator.py
+++ b/FloorplanToBlenderLib/generator.py
@@ -126,18 +126,8 @@ class Wall(Generator):
         # detect contour
         contour, _ = detect.outer_contours(gray)
 
-        # get bounding Rect of the outer_contours
-        (x, y, w, h) = cv2.boundingRect(contour)
-        p1 = [x, y]
-        p2 = [x, y + h]
-        p3 = [x + w, y + h]
-        p4 = [x + w, y]
-        pts = np.array([p1, p2, p3, p4], np.int32)
-        pts = pts.reshape(-1, 1, 2)
-
         # remove walls outside of contour
-        boxes = calculate.remove_walls_not_in_contour(boxes, pts)
-        # boxes = calculate.remove_walls_not_in_contour(boxes, contour)
+        boxes = calculate.remove_walls_not_in_contour(boxes, contour)
         # Convert boxes to verts and faces, vertically
         self.verts, self.faces, wall_amount = transform.create_nx4_verts_and_faces(
             boxes=boxes,


### PR DESCRIPTION
Hi @grebtsew 

I love testing your project and was surprised at how good and easily understandable code you wrote.

It would be grateful for you to take a look at my code and test it on various examples.

The code I wrote will include walls even when some part of the wall contour is inside of the house outer contour.

The code you wrote sometimes excluded walls on the outer part of the house.
The contour of the walls were loose compared to the contour of the house.
This resulted in the outer contour of the walls being outside of the house contour
![output](https://user-images.githubusercontent.com/43432293/180639329-e27d06ca-192d-4769-9a57-7d26f2623eff.png)
If you see the image above the yellow contour is the house contour and the red contour is the wall contour. You can see that the outer wall red contour is outside of the yellow contour.

I thought that only checking the four corners of the bounding rectangle box of the wall was to little of a information to check if the wall was part of the house or not.
Therefore, instead of checking only the four corners of the bounding rectangle box I checked on all points in the wall and if at least one point was inside the house contour I defined the wall as the house wall.

Thank you for your time 


