### PR TITLE
fix python version used in server mode

### DIFF
--- a/Docker/docker-entrypoint.sh
+++ b/Docker/docker-entrypoint.sh
@@ -8,7 +8,7 @@ if  [ "$1" = "server" ]; then
     echo "Moving To server folder"
     cd /home/floorplan_to_blender/Server
     echo "Starting server"
-    python3 ./main.py
+    python3.8 ./main.py
 elif [ "$1" = "jupyter" ]; then
     echo "Start jupyter notebook on port 8888"
     jupyter notebook /home/floorplan_to_blender/ --port=8888 --ip=0.0.0.0 --allow-root --no-browser --NotebookApp.token=''


### PR DESCRIPTION
***Description***
The following error was getting thrown when running docker compose in server mode.
```
Traceback (most recent call last):
  File "./main.py", line 11, in <module>
    from swagger.swagger_flask import Swagger
  File "/home/floorplan_to_blender/Server/swagger/swagger_flask.py", line 20, in <module>
    from swagger.json_generator import generate_swagger_json
  File "/home/floorplan_to_blender/Server/swagger/json_generator.py", line 10, in <module>
    import requests
ModuleNotFoundError: No module named 'requests'
```

***Cause***

This was caused by a version typo in entry-point script. 


